### PR TITLE
Add compiled MOBI6 navigation

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod epub;
 pub mod library;
 pub mod matching;
 pub mod mobi;
+pub mod mobi_index;
 
 pub use library::{Book, KatalogError, Library};
 

--- a/core/src/mobi.rs
+++ b/core/src/mobi.rs
@@ -60,8 +60,12 @@ fn read_epub(path: &Path) -> Result<Source, String> {
             .value()
             .map(str::to_string)
             .unwrap_or_default();
-        let Ok(bytes) = entry.read_bytes() else { continue };
-        recindex.entry(basename(&href).to_string()).or_insert(images.len() + 1);
+        let Ok(bytes) = entry.read_bytes() else {
+            continue;
+        };
+        recindex
+            .entry(basename(&href).to_string())
+            .or_insert(images.len() + 1);
         images.push(optimize_image(bytes));
     }
 
@@ -90,8 +94,14 @@ fn read_epub(path: &Path) -> Result<Source, String> {
     let mut reader = epub.reader();
     while let Some(next) = reader.read_next() {
         let data = next.map_err(|e| format!("read spine: {e}"))?;
-        let href = basename(data.manifest_entry().resource().key().value().unwrap_or_default())
-            .to_string();
+        let href = basename(
+            data.manifest_entry()
+                .resource()
+                .key()
+                .value()
+                .unwrap_or_default(),
+        )
+        .to_string();
         let inner = rewrite_images(body_inner(data.content()), &recindex);
 
         if !first {
@@ -135,17 +145,17 @@ fn read_epub(path: &Path) -> Result<Source, String> {
     if let Some(root) = epub.toc().contents() {
         for entry in root.flatten() {
             let label = entry.label().trim();
-            let Some(href) = entry.resource().and_then(|r| r.key().value().map(str::to_string))
-            else {
+            let Some(href) = entry.href() else {
                 continue;
             };
             if label.is_empty() {
                 continue;
             }
-            if let Some(off) = resolve_offset(&href, &doc_start, &id_at) {
+            if let Some(off) = resolve_offset(href.as_str(), &doc_start, &id_at) {
                 toc.push(crate::mobi_index::TocEntry {
                     label: label.to_string(),
                     offset: off as u32,
+                    depth: entry.depth().saturating_sub(1),
                 });
             }
         }
@@ -234,7 +244,11 @@ fn rewrite_links(inner: &str, base: &str) -> (String, Vec<Link>, Vec<(String, us
                 let digit_pos = out.len() + "filepos=\"".len();
                 out.push_str("filepos=\"0000000000\"");
                 out.push_str(&tag[hpos + hlen..]);
-                links.push(Link { digit_pos, target, frag });
+                links.push(Link {
+                    digit_pos,
+                    target,
+                    frag,
+                });
                 i = end;
                 continue;
             }
@@ -251,8 +265,11 @@ fn rewrite_links(inner: &str, base: &str) -> (String, Vec<Link>, Vec<(String, us
 /// links (http/mailto/etc.), which are left untouched.
 fn internal_target(href: &str, base: &str) -> Option<(String, Option<String>)> {
     let href = href.trim();
-    if href.is_empty() || href.contains("://") || href.starts_with("mailto:")
-        || href.starts_with("tel:") || href.starts_with("//")
+    if href.is_empty()
+        || href.contains("://")
+        || href.starts_with("mailto:")
+        || href.starts_with("tel:")
+        || href.starts_with("//")
     {
         return None;
     }
@@ -260,7 +277,11 @@ fn internal_target(href: &str, base: &str) -> Option<(String, Option<String>)> {
         Some((p, f)) => (p, Some(f.to_string())),
         None => (href, None),
     };
-    let target = if path.is_empty() { base.to_string() } else { basename(path).to_string() };
+    let target = if path.is_empty() {
+        base.to_string()
+    } else {
+        basename(path).to_string()
+    };
     Some((target, frag))
 }
 
@@ -340,7 +361,12 @@ fn optimize_image(bytes: Vec<u8>) -> Vec<u8> {
         use image::{ExtendedColorType, ImageEncoder};
         let enc = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
         if enc
-            .write_image(rgb.as_raw(), rgb.width(), rgb.height(), ExtendedColorType::Rgb8)
+            .write_image(
+                rgb.as_raw(),
+                rgb.width(),
+                rgb.height(),
+                ExtendedColorType::Rgb8,
+            )
             .is_err()
         {
             break;
@@ -430,8 +456,18 @@ fn build_mobi(src: &Source) -> Vec<u8> {
         src,
         text_len,
         n_text,
-        /* first_index_record */ if index.is_some() { first_index_record as u32 } else { NONE },
-        /* first_image_index */ if n_images > 0 { first_image_record as u32 } else { NONE },
+        /* first_index_record */
+        if index.is_some() {
+            first_index_record as u32
+        } else {
+            NONE
+        },
+        /* first_image_index */
+        if n_images > 0 {
+            first_image_record as u32
+        } else {
+            NONE
+        },
         /* first_non_book_index */ (last_text + 1) as u32,
         /* last_content_record */ (flis_index - 1) as u16,
         fcis_index as u32,
@@ -505,7 +541,7 @@ fn utf8_chunks(mut data: &[u8], max: usize) -> impl Iterator<Item = &[u8]> {
 fn palmdoc_header(text_len: u32, n_text: usize) -> [u8; 16] {
     let mut h = [0u8; 16];
     h[0..2].copy_from_slice(&2u16.to_be_bytes()); // compression: PalmDOC
-    // 2..4 unused
+                                                  // 2..4 unused
     h[4..8].copy_from_slice(&text_len.to_be_bytes());
     h[8..10].copy_from_slice(&(n_text as u16).to_be_bytes());
     h[10..12].copy_from_slice(&(TEXT_RECORD_SIZE as u16).to_be_bytes());
@@ -886,6 +922,7 @@ mod tests {
             html: vec![],
             images: vec![],
             cover_recindex: None,
+            toc: Vec::new(),
         });
         assert_eq!(u32::from_be_bytes(exth[8..12].try_into().unwrap()), 2);
         assert_eq!(u32::from_be_bytes(exth[12..16].try_into().unwrap()), 100);
@@ -902,9 +939,12 @@ mod tests {
     fn record_layout_matches_mobi6_conventions() {
         let src = Source {
             title: "é".into(), authors: vec!["A".into()], isbn: None,
-            description: None, html: vec![], images: vec![], cover_recindex: None,
+            description: None, publisher: None, subjects: vec![], publication_date: None,
+            contributors: vec![], rights: None, source: None, language: None,
+            html: vec![], images: vec![], cover_recindex: None,
+            toc: Vec::new(),
         };
-        let rec = build_record0(&src, 0, 1, NONE, 2, 1, 3, 2);
+        let rec = build_record0(&src, 0, 1, NONE, NONE, 2, 1, 3, 2);
         let at = |n| u32::from_be_bytes(rec[n..n + 4].try_into().unwrap());
         let title = at(16 + 68) as usize;
         assert_eq!(&rec[title..], &[0xc3, 0xa9, 0, 0]);
@@ -942,6 +982,7 @@ mod tests {
             html: vec![],
             images: vec![],
             cover_recindex: None,
+            toc: Vec::new(),
         });
         let mut records = Vec::new();
         let mut offset = 12;
@@ -977,7 +1018,11 @@ mod palmdoc_tests {
 
     fn roundtrip(data: &[u8]) {
         let c = palmdoc_compress(data);
-        assert_eq!(palmdoc_decompress(&c), data, "roundtrip failed for {data:?}");
+        assert_eq!(
+            palmdoc_decompress(&c),
+            data,
+            "roundtrip failed for {data:?}"
+        );
     }
 
     #[test]

--- a/core/src/mobi.rs
+++ b/core/src/mobi.rs
@@ -39,6 +39,8 @@ struct Source {
     images: Vec<Vec<u8>>,
     /// 0-based index into `images` of the cover, for EXTH 201.
     cover_recindex: Option<usize>,
+    /// Resolved TOC entries (label + byte offset) for the NCX index.
+    toc: Vec<crate::mobi_index::TocEntry>,
 }
 
 fn read_epub(path: &Path) -> Result<Source, String> {
@@ -126,6 +128,29 @@ fn read_epub(path: &Path) -> Result<Source, String> {
         write_filepos(&mut html, link.digit_pos, offset);
     }
 
+    // Extract the TOC and resolve each entry to a byte offset, reusing the same
+    // anchor maps as the filepos links. Offsets are final: patching filepos above
+    // only overwrites fixed-width digits, never shifts bytes.
+    let mut toc = Vec::new();
+    if let Some(root) = epub.toc().contents() {
+        for entry in root.flatten() {
+            let label = entry.label().trim();
+            let Some(href) = entry.resource().and_then(|r| r.key().value().map(str::to_string))
+            else {
+                continue;
+            };
+            if label.is_empty() {
+                continue;
+            }
+            if let Some(off) = resolve_offset(&href, &doc_start, &id_at) {
+                toc.push(crate::mobi_index::TocEntry {
+                    label: label.to_string(),
+                    offset: off as u32,
+                });
+            }
+        }
+    }
+
     Ok(Source {
         authors: meta.authors,
         isbn: meta.isbn,
@@ -141,7 +166,20 @@ fn read_epub(path: &Path) -> Result<Source, String> {
         html,
         images,
         cover_recindex,
+        toc,
     })
+}
+
+/// Resolve a TOC/link href to its byte offset (id anchor if it has a #fragment,
+/// else the document start), reusing the flatten pass's anchor maps.
+fn resolve_offset(
+    href: &str,
+    doc_start: &HashMap<String, usize>,
+    id_at: &HashMap<(String, String), usize>,
+) -> Option<usize> {
+    let (target, frag) = internal_target(href, "")?;
+    frag.and_then(|f| id_at.get(&(target.clone(), f)).copied())
+        .or_else(|| doc_start.get(&target).copied())
 }
 
 /// A rewritten internal link awaiting its resolved filepos.
@@ -375,17 +413,24 @@ fn build_mobi(src: &Source) -> Vec<u8> {
     };
     let n_text = text_records.len();
 
-    // Record numbering: 0 = header, 1..=n_text = text, then images, FLIS, FCIS, EOF.
+    // Record numbering: 0 = header, 1..=n_text = text, then the NCX index (INDX
+    // header, INDX entries, CNCX — must be contiguous, in that order), then
+    // images, FLIS, FCIS, EOF.
     let last_text = n_text; // 1-based record index of the last text record
     let n_images = src.images.len();
-    let first_image_record = last_text + 1; // record index of image #1 (recindex 1)
-    let flis_index = last_text + n_images + 1;
+
+    let index = crate::mobi_index::build_ncx(&src.toc, text_len);
+    let n_index = if index.is_some() { 3 } else { 0 };
+    let first_index_record = last_text + 1; // INDX header record
+    let first_image_record = last_text + n_index + 1; // image #1 (recindex 1)
+    let flis_index = last_text + n_index + n_images + 1;
     let fcis_index = flis_index + 1;
 
     let record0 = build_record0(
         src,
         text_len,
         n_text,
+        /* first_index_record */ if index.is_some() { first_index_record as u32 } else { NONE },
         /* first_image_index */ if n_images > 0 { first_image_record as u32 } else { NONE },
         /* first_non_book_index */ (last_text + 1) as u32,
         /* last_content_record */ (flis_index - 1) as u16,
@@ -393,9 +438,14 @@ fn build_mobi(src: &Source) -> Vec<u8> {
         flis_index as u32,
     );
 
-    let mut records: Vec<Vec<u8>> = Vec::with_capacity(n_text + n_images + 4);
+    let mut records: Vec<Vec<u8>> = Vec::with_capacity(n_text + n_index + n_images + 4);
     records.push(record0);
     records.extend(text_records);
+    if let Some(idx) = &index {
+        records.push(idx.header.clone());
+        records.push(idx.entries.clone());
+        records.push(idx.cncx.clone());
+    }
     records.extend(src.images.iter().cloned());
     records.push(flis_record());
     records.push(fcis_record(text_len));
@@ -404,10 +454,12 @@ fn build_mobi(src: &Source) -> Vec<u8> {
     write_pdb(&src.title, &records)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_record0(
     src: &Source,
     text_len: u32,
     n_text: usize,
+    first_index_record: u32,
     first_image_index: u32,
     first_non_book_index: u32,
     last_content_record: u16,
@@ -423,6 +475,7 @@ fn build_record0(
     rec.extend_from_slice(&mobi_header(
         name_offset as u32,
         name.len() as u32,
+        first_index_record,
         first_image_index,
         first_non_book_index,
         last_content_record,
@@ -461,9 +514,11 @@ fn palmdoc_header(text_len: u32, n_text: usize) -> [u8; 16] {
 }
 
 /// The 232-byte MOBI header, fields in the exact order the `mobi` crate parses.
+#[allow(clippy::too_many_arguments)]
 fn mobi_header(
     name_offset: u32,
     name_length: u32,
+    first_index_record: u32,
     first_image_index: u32,
     first_non_book_index: u32,
     last_content_record: u16,
@@ -523,7 +578,7 @@ fn mobi_header(
     u32(&mut h, NONE); // data_section_count
     u32(&mut h, NONE); // unknown, conventional MOBI6 value
     u32(&mut h, 0); // extra_record_data_flags: no trailing bytes on text records
-    u32(&mut h, NONE); // first_index_record
+    u32(&mut h, first_index_record); // first INDX (NCX) record, or NONE
 
     debug_assert_eq!(h.len(), MOBI_HEADER_LEN as usize);
     h

--- a/core/src/mobi_index.rs
+++ b/core/src/mobi_index.rs
@@ -5,16 +5,14 @@
 //! Calibre-produced .mobi (field-by-field, varints verified against real
 //! entries), not copied from GPL source.
 //!
-//! ponytail: FLAT TOC only — the epub's nav tree is walked in reading order and
-//! emitted as a single-level list (tags offset/length/label/depth, depth always
-//! 0). Nested TOC (parent/child tags 21–23) is a later addition. If the entries
-//! or labels don't fit one 64 KB record, we return None and the book ships with
+//! If the entries or labels don't fit one 64 KB record, we return None and the book ships with
 //! no index (exactly today's behavior) rather than risk a corrupt one.
 
 /// A resolved TOC entry: its label and the byte offset it points at in the text.
 pub struct TocEntry {
     pub label: String,
     pub offset: u32,
+    pub depth: usize,
 }
 
 /// The three records that make up the index, in order.
@@ -42,7 +40,15 @@ fn vwi(mut n: u32) -> Vec<u8> {
 }
 
 /// The 192-byte INDX record header, zero-padded after the 13 longwords.
-fn indx_header(type_: u32, gen: u32, idxt_start: u32, count: u32, code: u32, total: u32, nctoc: u32) -> Vec<u8> {
+fn indx_header(
+    type_: u32,
+    gen: u32,
+    idxt_start: u32,
+    count: u32,
+    code: u32,
+    total: u32,
+    nctoc: u32,
+) -> Vec<u8> {
     let mut h = Vec::with_capacity(INDX_HEADER_LEN as usize);
     h.extend_from_slice(b"INDX");
     for v in [
@@ -63,16 +69,39 @@ fn indx_header(type_: u32, gen: u32, idxt_start: u32, count: u32, code: u32, tot
         h.extend_from_slice(&v.to_be_bytes());
     }
     h.resize(INDX_HEADER_LEN as usize, 0);
+    if type_ == 0 {
+        h[0xB4..0xB8].copy_from_slice(&INDX_HEADER_LEN.to_be_bytes());
+    }
     h
 }
 
-/// Fixed TAGX table for a flat NCX: tags offset(1)/length(2)/label(3)/depth(4).
-fn tagx() -> Vec<u8> {
+/// NCX tags: offset, length, label, depth and optional hierarchy links.
+fn tagx(nested: bool) -> Vec<u8> {
+    let tags = if nested {
+        vec![
+            (1, 1, 0x01, 0),
+            (2, 1, 0x02, 0),
+            (3, 1, 0x04, 0),
+            (4, 1, 0x08, 0),
+            (21, 1, 0x10, 0),
+            (22, 1, 0x20, 0),
+            (23, 1, 0x40, 0),
+            (0, 0, 0, 1),
+        ]
+    } else {
+        vec![
+            (1, 1, 0x01, 0),
+            (2, 1, 0x02, 0),
+            (3, 1, 0x04, 0),
+            (4, 1, 0x08, 0),
+            (0, 0, 0, 1),
+        ]
+    };
     let mut t = Vec::new();
     t.extend_from_slice(b"TAGX");
-    t.extend_from_slice(&32u32.to_be_bytes()); // length (12 + 5*4)
+    t.extend_from_slice(&(12u32 + tags.len() as u32 * 4).to_be_bytes());
     t.extend_from_slice(&1u32.to_be_bytes()); // control byte count
-    for (tag, nvals, mask, end) in [(1, 1, 0x01, 0), (2, 1, 0x02, 0), (3, 1, 0x04, 0), (4, 1, 0x08, 0), (0, 0, 0, 1)] {
+    for (tag, nvals, mask, end) in tags {
         t.extend_from_slice(&[tag, nvals, mask, end]);
     }
     t
@@ -81,10 +110,7 @@ fn tagx() -> Vec<u8> {
 /// Build the NCX index for `toc`. `text_len` bounds the last entry's length.
 /// Returns None if there's nothing to index or it wouldn't fit one record each.
 pub fn build_ncx(toc: &[TocEntry], text_len: u32) -> Option<Index> {
-    // Sort by target offset (the index must be ascending) and drop duplicates.
-    let mut items: Vec<&TocEntry> = toc.iter().filter(|e| e.offset < text_len).collect();
-    items.sort_by_key(|e| e.offset);
-    items.dedup_by_key(|e| e.offset);
+    let items: Vec<&TocEntry> = toc.iter().filter(|e| e.offset < text_len).collect();
     if items.is_empty() {
         return None;
     }
@@ -92,6 +118,24 @@ pub fn build_ncx(toc: &[TocEntry], text_len: u32) -> Option<Index> {
     if n > 0xFFFF {
         return None; // absurd TOC — fall back to no index
     }
+
+    // Convert EPUB depths to parent/child entry indices after invalid entries
+    // have been removed. A missing parent promotes its children one level.
+    let mut parents = vec![None; n];
+    let mut children: Vec<Vec<usize>> = vec![Vec::new(); n];
+    let mut stack: Vec<usize> = Vec::new();
+    let mut depths = Vec::with_capacity(n);
+    for (i, e) in items.iter().enumerate() {
+        stack.truncate(e.depth.min(stack.len()));
+        let parent = stack.last().copied();
+        parents[i] = parent;
+        if let Some(p) = parent {
+            children[p].push(i);
+        }
+        depths.push(stack.len());
+        stack.push(i);
+    }
+    let nested = parents.iter().any(Option::is_some);
 
     // CNCX: [vwi(byte-len)][utf8] per label; label offset = its byte position.
     let mut cncx = Vec::new();
@@ -125,11 +169,25 @@ pub fn build_ncx(toc: &[TocEntry], text_len: u32) -> Option<Index> {
         let mut blk = Vec::new();
         blk.push(ident.len() as u8);
         blk.extend_from_slice(ident.as_bytes());
-        blk.push(0x0F); // control byte: tags 1,2,3,4 present
+        let mut control = 0x0F; // offset, length, label and depth
+        if parents[i].is_some() {
+            control |= 0x10;
+        }
+        if !children[i].is_empty() {
+            control |= 0x60;
+        }
+        blk.push(control);
         blk.extend_from_slice(&vwi(e.offset));
         blk.extend_from_slice(&vwi(length));
         blk.extend_from_slice(&vwi(label_off[i]));
-        blk.extend_from_slice(&vwi(0)); // depth
+        blk.extend_from_slice(&vwi(depths[i] as u32));
+        if let Some(parent) = parents[i] {
+            blk.extend_from_slice(&vwi(parent as u32));
+        }
+        if let (Some(first), Some(last)) = (children[i].first(), children[i].last()) {
+            blk.extend_from_slice(&vwi(*first as u32));
+            blk.extend_from_slice(&vwi(*last as u32));
+        }
         entry_offsets.push(cursor as u16);
         cursor += blk.len();
         blocks.extend_from_slice(&blk);
@@ -150,8 +208,8 @@ pub fn build_ncx(toc: &[TocEntry], text_len: u32) -> Option<Index> {
 
     // Index-header record: header(type=0) + TAGX + geometry entry + IDXT.
     let mut header = indx_header(0, 2, 0, 1, 65001, n as u32, 1);
-    header.extend_from_slice(&tagx());
-    let geom_off = header.len() as u16; // = 224 (0xC0 + 0x20)
+    header.extend_from_slice(&tagx(nested));
+    let geom_off = header.len() as u16;
     let last_ident = format!("{:0width$X}", n - 1, width = width);
     header.push(last_ident.len() as u8);
     header.extend_from_slice(last_ident.as_bytes());
@@ -164,7 +222,11 @@ pub fn build_ncx(toc: &[TocEntry], text_len: u32) -> Option<Index> {
     // Patch the header's IDXT-start field (offset 0x14) now that we know it.
     header[0x14..0x18].copy_from_slice(&hdr_idxt.to_be_bytes());
 
-    Some(Index { header, entries, cncx })
+    Some(Index {
+        header,
+        entries,
+        cncx,
+    })
 }
 
 fn pad4(v: &mut Vec<u8>) {
@@ -189,7 +251,7 @@ mod tests {
     #[test]
     fn tagx_bytes_match_calibre() {
         assert_eq!(
-            tagx(),
+            tagx(false),
             vec![
                 b'T', b'A', b'G', b'X', 0, 0, 0, 32, 0, 0, 0, 1, //
                 1, 1, 1, 0, 2, 1, 2, 0, 3, 1, 4, 0, 4, 1, 8, 0, 0, 0, 0, 1,
@@ -200,32 +262,129 @@ mod tests {
     #[test]
     fn builds_a_flat_index_that_round_trips() {
         let toc = vec![
-            TocEntry { label: "Title Page".into(), offset: 3643 },
-            TocEntry { label: "Copyright".into(), offset: 3777 },
-            TocEntry { label: "Chapter One".into(), offset: 5718 },
+            TocEntry {
+                label: "Title Page".into(),
+                offset: 3643,
+                depth: 0,
+            },
+            TocEntry {
+                label: "Copyright".into(),
+                offset: 3777,
+                depth: 0,
+            },
+            TocEntry {
+                label: "Chapter One".into(),
+                offset: 5718,
+                depth: 0,
+            },
         ];
         let idx = build_ncx(&toc, 10_000).expect("index built");
 
         // Header record: magic, len, type 0, count 1, code 65001, total 3, nctoc 1.
         assert_eq!(&idx.header[0..4], b"INDX");
-        assert_eq!(u32::from_be_bytes(idx.header[0x0C..0x10].try_into().unwrap()), 0);
-        assert_eq!(u32::from_be_bytes(idx.header[0x18..0x1C].try_into().unwrap()), 1);
-        assert_eq!(u32::from_be_bytes(idx.header[0x1C..0x20].try_into().unwrap()), 65001);
-        assert_eq!(u32::from_be_bytes(idx.header[0x24..0x28].try_into().unwrap()), 3);
+        assert_eq!(
+            u32::from_be_bytes(idx.header[0x0C..0x10].try_into().unwrap()),
+            0
+        );
+        assert_eq!(
+            u32::from_be_bytes(idx.header[0x18..0x1C].try_into().unwrap()),
+            1
+        );
+        assert_eq!(
+            u32::from_be_bytes(idx.header[0x1C..0x20].try_into().unwrap()),
+            65001
+        );
+        assert_eq!(
+            u32::from_be_bytes(idx.header[0x24..0x28].try_into().unwrap()),
+            3
+        );
         assert_eq!(&idx.header[0xC0..0xC4], b"TAGX");
 
         // Entry record: type 1, count 3, then decode entry 0 and check it.
-        assert_eq!(u32::from_be_bytes(idx.entries[0x0C..0x10].try_into().unwrap()), 1);
-        assert_eq!(u32::from_be_bytes(idx.entries[0x18..0x1C].try_into().unwrap()), 3);
+        assert_eq!(
+            u32::from_be_bytes(idx.entries[0x0C..0x10].try_into().unwrap()),
+            1
+        );
+        assert_eq!(
+            u32::from_be_bytes(idx.entries[0x18..0x1C].try_into().unwrap()),
+            3
+        );
         let e0 = &idx.entries[0xC0..];
         assert_eq!(e0[0], 2); // ident length
         assert_eq!(&e0[1..3], b"00"); // ident
         assert_eq!(e0[3], 0x0F); // control byte
-        // offset varint = 3643
+                                 // offset varint = 3643
         assert_eq!(&e0[4..6], &[0x1c, 0xbb]);
 
         // CNCX: first label is length-prefixed "Title Page".
         assert_eq!(idx.cncx[0], 0x80 | 10);
         assert_eq!(&idx.cncx[1..11], b"Title Page");
+    }
+
+    #[test]
+    fn preserves_nested_toc_order_and_relationships() {
+        let toc = vec![
+            TocEntry {
+                label: "Part".into(),
+                offset: 100,
+                depth: 0,
+            },
+            TocEntry {
+                label: "Chapter".into(),
+                offset: 200,
+                depth: 1,
+            },
+            TocEntry {
+                label: "Section".into(),
+                offset: 250,
+                depth: 2,
+            },
+            TocEntry {
+                label: "Appendix".into(),
+                offset: 300,
+                depth: 1,
+            },
+        ];
+        let idx = build_ncx(&toc, 1_000).unwrap();
+        assert_eq!(
+            &idx.header[0xC0 + 28..0xC0 + 40],
+            &[21, 1, 16, 0, 22, 1, 32, 0, 23, 1, 64, 0]
+        );
+
+        let idxt = u32::from_be_bytes(idx.entries[0x14..0x18].try_into().unwrap()) as usize;
+        let offsets: Vec<usize> = (0..toc.len())
+            .map(|i| {
+                u16::from_be_bytes(
+                    idx.entries[idxt + 4 + i * 2..idxt + 6 + i * 2]
+                        .try_into()
+                        .unwrap(),
+                ) as usize
+            })
+            .collect();
+        let decode = |i: usize, count: usize| {
+            let mut pos = offsets[i];
+            pos += 1 + idx.entries[pos] as usize;
+            let control = idx.entries[pos];
+            pos += 1;
+            let mut values = Vec::new();
+            for _ in 0..count {
+                let mut value = 0;
+                loop {
+                    let byte = idx.entries[pos];
+                    pos += 1;
+                    value = (value << 7) | u32::from(byte & 0x7f);
+                    if byte & 0x80 != 0 {
+                        break;
+                    }
+                }
+                values.push(value);
+            }
+            (control, values)
+        };
+
+        assert_eq!(decode(0, 6), (0x6f, vec![100, 100, 0, 0, 1, 3]));
+        assert_eq!(decode(1, 7), (0x7f, vec![200, 50, 5, 1, 0, 2, 2]));
+        assert_eq!(decode(2, 5), (0x1f, vec![250, 50, 13, 2, 1]));
+        assert_eq!(decode(3, 5), (0x1f, vec![300, 700, 21, 1, 0]));
     }
 }

--- a/core/src/mobi_index.rs
+++ b/core/src/mobi_index.rs
@@ -1,0 +1,231 @@
+//! MOBI6 NCX table-of-contents index (INDX / TAGX / IDXT / CNCX records).
+//!
+//! Drives the Kindle's hardware "Go To → Table of Contents" menu and chapter
+//! location marks. Clean-room: every byte layout below was decoded from a
+//! Calibre-produced .mobi (field-by-field, varints verified against real
+//! entries), not copied from GPL source.
+//!
+//! ponytail: FLAT TOC only — the epub's nav tree is walked in reading order and
+//! emitted as a single-level list (tags offset/length/label/depth, depth always
+//! 0). Nested TOC (parent/child tags 21–23) is a later addition. If the entries
+//! or labels don't fit one 64 KB record, we return None and the book ships with
+//! no index (exactly today's behavior) rather than risk a corrupt one.
+
+/// A resolved TOC entry: its label and the byte offset it points at in the text.
+pub struct TocEntry {
+    pub label: String,
+    pub offset: u32,
+}
+
+/// The three records that make up the index, in order.
+pub struct Index {
+    pub header: Vec<u8>,
+    pub entries: Vec<u8>,
+    pub cncx: Vec<u8>,
+}
+
+const INDX_HEADER_LEN: u32 = 0xC0; // 192 — where TAGX (header rec) / entries begin
+
+/// MOBI variable-width integer: base-128, most-significant group first, with the
+/// terminator bit (0x80) set on the LAST byte. (Verified: 3643 → `1c bb`.)
+fn vwi(mut n: u32) -> Vec<u8> {
+    let mut out = vec![(n & 0x7f) as u8];
+    n >>= 7;
+    while n > 0 {
+        out.push((n & 0x7f) as u8);
+        n >>= 7;
+    }
+    out.reverse();
+    let last = out.len() - 1;
+    out[last] |= 0x80;
+    out
+}
+
+/// The 192-byte INDX record header, zero-padded after the 13 longwords.
+fn indx_header(type_: u32, gen: u32, idxt_start: u32, count: u32, code: u32, total: u32, nctoc: u32) -> Vec<u8> {
+    let mut h = Vec::with_capacity(INDX_HEADER_LEN as usize);
+    h.extend_from_slice(b"INDX");
+    for v in [
+        INDX_HEADER_LEN, // len
+        0,               // nul1
+        type_,           // type: 0 = index-header record, 1 = entry record
+        gen,             // gen
+        idxt_start,      // IDXT offset within this record
+        count,           // entries in this record (header rec: 1)
+        code,            // encoding: 65001 header rec, 0xFFFFFFFF entry rec
+        0xFFFF_FFFF,     // lng
+        total,           // total entries across entry records (header rec only)
+        0,               // ordt
+        0,               // ligt
+        0,               // nligt
+        nctoc,           // CNCX record count (header rec: 1)
+    ] {
+        h.extend_from_slice(&v.to_be_bytes());
+    }
+    h.resize(INDX_HEADER_LEN as usize, 0);
+    h
+}
+
+/// Fixed TAGX table for a flat NCX: tags offset(1)/length(2)/label(3)/depth(4).
+fn tagx() -> Vec<u8> {
+    let mut t = Vec::new();
+    t.extend_from_slice(b"TAGX");
+    t.extend_from_slice(&32u32.to_be_bytes()); // length (12 + 5*4)
+    t.extend_from_slice(&1u32.to_be_bytes()); // control byte count
+    for (tag, nvals, mask, end) in [(1, 1, 0x01, 0), (2, 1, 0x02, 0), (3, 1, 0x04, 0), (4, 1, 0x08, 0), (0, 0, 0, 1)] {
+        t.extend_from_slice(&[tag, nvals, mask, end]);
+    }
+    t
+}
+
+/// Build the NCX index for `toc`. `text_len` bounds the last entry's length.
+/// Returns None if there's nothing to index or it wouldn't fit one record each.
+pub fn build_ncx(toc: &[TocEntry], text_len: u32) -> Option<Index> {
+    // Sort by target offset (the index must be ascending) and drop duplicates.
+    let mut items: Vec<&TocEntry> = toc.iter().filter(|e| e.offset < text_len).collect();
+    items.sort_by_key(|e| e.offset);
+    items.dedup_by_key(|e| e.offset);
+    if items.is_empty() {
+        return None;
+    }
+    let n = items.len();
+    if n > 0xFFFF {
+        return None; // absurd TOC — fall back to no index
+    }
+
+    // CNCX: [vwi(byte-len)][utf8] per label; label offset = its byte position.
+    let mut cncx = Vec::new();
+    let mut label_off = Vec::with_capacity(n);
+    for e in &items {
+        label_off.push(cncx.len() as u32);
+        let bytes = e.label.as_bytes();
+        cncx.extend_from_slice(&vwi(bytes.len() as u32));
+        cncx.extend_from_slice(bytes);
+    }
+    if cncx.len() > 0xFFFF {
+        return None;
+    }
+
+    // Entry idents: fixed-width uppercase hex of the entry number.
+    let mut width = format!("{:X}", n.saturating_sub(1)).len();
+    if width % 2 == 1 {
+        width += 1;
+    }
+    width = width.max(2);
+
+    // Entry blocks + their offsets (relative to the entry record start).
+    let mut blocks = Vec::new();
+    let mut entry_offsets = Vec::with_capacity(n);
+    let mut cursor = INDX_HEADER_LEN as usize;
+    for (i, e) in items.iter().enumerate() {
+        let next = items.get(i + 1).map(|x| x.offset).unwrap_or(text_len);
+        let length = next.saturating_sub(e.offset);
+        let ident = format!("{:0width$X}", i, width = width);
+
+        let mut blk = Vec::new();
+        blk.push(ident.len() as u8);
+        blk.extend_from_slice(ident.as_bytes());
+        blk.push(0x0F); // control byte: tags 1,2,3,4 present
+        blk.extend_from_slice(&vwi(e.offset));
+        blk.extend_from_slice(&vwi(length));
+        blk.extend_from_slice(&vwi(label_off[i]));
+        blk.extend_from_slice(&vwi(0)); // depth
+        entry_offsets.push(cursor as u16);
+        cursor += blk.len();
+        blocks.extend_from_slice(&blk);
+    }
+    if cursor + 4 + n * 2 > 0xFFFF {
+        return None; // entries + IDXT don't fit one record
+    }
+
+    // Entry record: header(type=1) + blocks + IDXT.
+    let idxt_start = INDX_HEADER_LEN as usize + blocks.len();
+    let mut entries = indx_header(1, 0, idxt_start as u32, n as u32, 0xFFFF_FFFF, 0, 0);
+    entries.extend_from_slice(&blocks);
+    entries.extend_from_slice(b"IDXT");
+    for off in &entry_offsets {
+        entries.extend_from_slice(&off.to_be_bytes());
+    }
+    pad4(&mut entries);
+
+    // Index-header record: header(type=0) + TAGX + geometry entry + IDXT.
+    let mut header = indx_header(0, 2, 0, 1, 65001, n as u32, 1);
+    header.extend_from_slice(&tagx());
+    let geom_off = header.len() as u16; // = 224 (0xC0 + 0x20)
+    let last_ident = format!("{:0width$X}", n - 1, width = width);
+    header.push(last_ident.len() as u8);
+    header.extend_from_slice(last_ident.as_bytes());
+    // Geometry tail as Calibre emits it: 0x00, entry-count byte, 0x00 0x00 0x00.
+    header.extend_from_slice(&[0x00, n as u8, 0x00, 0x00, 0x00]);
+    let hdr_idxt = header.len() as u32;
+    header.extend_from_slice(b"IDXT");
+    header.extend_from_slice(&geom_off.to_be_bytes());
+    pad4(&mut header);
+    // Patch the header's IDXT-start field (offset 0x14) now that we know it.
+    header[0x14..0x18].copy_from_slice(&hdr_idxt.to_be_bytes());
+
+    Some(Index { header, entries, cncx })
+}
+
+fn pad4(v: &mut Vec<u8>) {
+    while v.len() % 4 != 0 {
+        v.push(0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vwi_matches_known_values() {
+        assert_eq!(vwi(0), vec![0x80]);
+        assert_eq!(vwi(0x7f), vec![0xff]);
+        assert_eq!(vwi(0x80), vec![0x01, 0x80]);
+        assert_eq!(vwi(3643), vec![0x1c, 0xbb]); // real Calibre entry offset
+        assert_eq!(vwi(134), vec![0x01, 0x86]); // real Calibre entry length
+    }
+
+    #[test]
+    fn tagx_bytes_match_calibre() {
+        assert_eq!(
+            tagx(),
+            vec![
+                b'T', b'A', b'G', b'X', 0, 0, 0, 32, 0, 0, 0, 1, //
+                1, 1, 1, 0, 2, 1, 2, 0, 3, 1, 4, 0, 4, 1, 8, 0, 0, 0, 0, 1,
+            ]
+        );
+    }
+
+    #[test]
+    fn builds_a_flat_index_that_round_trips() {
+        let toc = vec![
+            TocEntry { label: "Title Page".into(), offset: 3643 },
+            TocEntry { label: "Copyright".into(), offset: 3777 },
+            TocEntry { label: "Chapter One".into(), offset: 5718 },
+        ];
+        let idx = build_ncx(&toc, 10_000).expect("index built");
+
+        // Header record: magic, len, type 0, count 1, code 65001, total 3, nctoc 1.
+        assert_eq!(&idx.header[0..4], b"INDX");
+        assert_eq!(u32::from_be_bytes(idx.header[0x0C..0x10].try_into().unwrap()), 0);
+        assert_eq!(u32::from_be_bytes(idx.header[0x18..0x1C].try_into().unwrap()), 1);
+        assert_eq!(u32::from_be_bytes(idx.header[0x1C..0x20].try_into().unwrap()), 65001);
+        assert_eq!(u32::from_be_bytes(idx.header[0x24..0x28].try_into().unwrap()), 3);
+        assert_eq!(&idx.header[0xC0..0xC4], b"TAGX");
+
+        // Entry record: type 1, count 3, then decode entry 0 and check it.
+        assert_eq!(u32::from_be_bytes(idx.entries[0x0C..0x10].try_into().unwrap()), 1);
+        assert_eq!(u32::from_be_bytes(idx.entries[0x18..0x1C].try_into().unwrap()), 3);
+        let e0 = &idx.entries[0xC0..];
+        assert_eq!(e0[0], 2); // ident length
+        assert_eq!(&e0[1..3], b"00"); // ident
+        assert_eq!(e0[3], 0x0F); // control byte
+        // offset varint = 3643
+        assert_eq!(&e0[4..6], &[0x1c, 0xbb]);
+
+        // CNCX: first label is length-prefixed "Title Page".
+        assert_eq!(idx.cncx[0], 0x80 | 10);
+        assert_eq!(&idx.cncx[1..11], b"Title Page");
+    }
+}


### PR DESCRIPTION
## Summary
- compile EPUB NCX/nav into MOBI6 INDX/TAGX/IDXT/CNCX records
- preserve TOC order, byte destinations, depth, and parent/child relationships
- wire first_index_record and record numbering into the writer

## Verification
- `cargo test` (32 passed)
- 8 representative local samples converted, Calibre-inspected, and round-tripped successfully
- mandatory regression sample: 89/89 labels in order, identical hierarchy, valid destinations, and successful Calibre round-trip

No source books or generated conversion artifacts are included.
