### PR TITLE
Preserve standard MOBI6 metadata

### DIFF
--- a/core/src/epub.rs
+++ b/core/src/epub.rs
@@ -11,6 +11,11 @@ pub struct ParsedEpub {
     pub authors: Vec<String>,
     pub language: Option<String>,
     pub publisher: Option<String>,
+    pub subjects: Vec<String>,
+    pub publication_date: Option<String>,
+    pub contributors: Vec<String>,
+    pub rights: Option<String>,
+    pub source: Option<String>,
     pub isbn: Option<String>,
     pub description: Option<String>,
     /// Calibre-compatible series metadata, when supplied by the EPUB.
@@ -32,6 +37,11 @@ pub fn parse(path: &Path) -> Result<ParsedEpub, String> {
 
     let authors: Vec<String> = md.creators().map(|c| c.value().to_string()).collect();
     let publisher = md.by_property("dc:publisher").next().map(|p| p.value().to_string());
+    let subjects = md.tags().map(|s| s.value().to_string()).collect();
+    let publication_date = md.published_entry().map(|d| d.value().to_string());
+    let contributors = md.contributors().map(|c| c.value().to_string()).collect();
+    let rights = md.rights().next().map(|r| r.value().to_string());
+    let source = md.by_property("dc:source").next().map(|s| s.value().to_string());
 
     // Prefer a real ISBN from any dc:identifier; the package's unique-identifier
     // is usually a uuid, useless for lookup and dedup. Store nothing rather
@@ -76,6 +86,11 @@ pub fn parse(path: &Path) -> Result<ParsedEpub, String> {
         authors,
         language: md.language().map(|l| l.value().to_string()),
         publisher,
+        subjects,
+        publication_date,
+        contributors,
+        rights,
+        source,
         isbn,
         description: md.description().map(|d| d.value().to_string()),
         // `calibre:series` and `calibre:series_index` are the de facto EPUB

--- a/core/src/mobi.rs
+++ b/core/src/mobi.rs
@@ -27,6 +27,13 @@ struct Source {
     authors: Vec<String>,
     isbn: Option<String>,
     description: Option<String>,
+    publisher: Option<String>,
+    subjects: Vec<String>,
+    publication_date: Option<String>,
+    contributors: Vec<String>,
+    rights: Option<String>,
+    source: Option<String>,
+    language: Option<String>,
     html: Vec<u8>,
     /// Image records in recindex order (image N is at index N-1).
     images: Vec<Vec<u8>>,
@@ -123,6 +130,13 @@ fn read_epub(path: &Path) -> Result<Source, String> {
         authors: meta.authors,
         isbn: meta.isbn,
         description: meta.description,
+        publisher: meta.publisher,
+        subjects: meta.subjects,
+        publication_date: meta.publication_date,
+        contributors: meta.contributors,
+        rights: meta.rights,
+        source: meta.source,
+        language: meta.language,
         title: meta.title,
         html,
         images,
@@ -516,6 +530,33 @@ fn build_exth(src: &Source) -> Vec<u8> {
     if let Some(i) = &src.isbn {
         recs.push((104, i.clone().into_bytes()));
     }
+    if let Some(p) = &src.publisher {
+        recs.push((101, p.clone().into_bytes()));
+    }
+    for subject in &src.subjects {
+        recs.push((105, subject.clone().into_bytes()));
+    }
+    if let Some(date) = &src.publication_date {
+        recs.push((106, date.clone().into_bytes()));
+    }
+    for contributor in &src.contributors {
+        if !src.authors.contains(contributor)
+            && !recs
+                .iter()
+                .any(|(ty, data)| *ty == 108 && data == contributor.as_bytes())
+        {
+            recs.push((108, contributor.clone().into_bytes()));
+        }
+    }
+    if let Some(rights) = &src.rights {
+        recs.push((109, rights.clone().into_bytes()));
+    }
+    if let Some(source) = &src.source {
+        recs.push((112, source.clone().into_bytes()));
+    }
+    if let Some(language) = &src.language {
+        recs.push((524, language.clone().into_bytes()));
+    }
     if let Some(cover) = src.cover_recindex {
         recs.push((201, (cover as u32).to_be_bytes().to_vec())); // cover image offset
         recs.push((202, (cover as u32).to_be_bytes().to_vec())); // thumbnail offset
@@ -770,6 +811,13 @@ mod tests {
             authors: vec!["Author".into(), "Translator".into()],
             isbn: None,
             description: None,
+            publisher: None,
+            subjects: vec![],
+            publication_date: None,
+            contributors: vec![],
+            rights: None,
+            source: None,
+            language: None,
             html: vec![],
             images: vec![],
             cover_recindex: None,
@@ -781,6 +829,56 @@ mod tests {
             u32::from_be_bytes(exth[second..second + 4].try_into().unwrap()),
             100
         );
+    }
+
+    #[test]
+    fn exth_preserves_source_metadata_and_repeats_multi_value_fields() {
+        let exth = build_exth(&Source {
+            title: "Book".into(),
+            authors: vec!["Author".into()],
+            isbn: None,
+            description: None,
+            publisher: Some("Publisher".into()),
+            subjects: vec!["One".into(), "Two".into()],
+            publication_date: Some("2024-01-02".into()),
+            contributors: vec![
+                "Author".into(),
+                "Editor".into(),
+                "Editor".into(),
+                "Translator".into(),
+            ],
+            rights: Some("Copyright".into()),
+            source: Some("Source edition".into()),
+            language: Some("de".into()),
+            html: vec![],
+            images: vec![],
+            cover_recindex: None,
+        });
+        let mut records = Vec::new();
+        let mut offset = 12;
+        for _ in 0..u32::from_be_bytes(exth[8..12].try_into().unwrap()) {
+            let ty = u32::from_be_bytes(exth[offset..offset + 4].try_into().unwrap());
+            let len = u32::from_be_bytes(exth[offset + 4..offset + 8].try_into().unwrap()) as usize;
+            records.push((
+                ty,
+                String::from_utf8_lossy(&exth[offset + 8..offset + len]).into_owned(),
+            ));
+            offset += len;
+        }
+        assert_eq!(records.iter().filter(|(ty, _)| *ty == 105).count(), 2);
+        assert_eq!(records.iter().filter(|(ty, _)| *ty == 108).count(), 2);
+        for expected in [
+            (101, "Publisher"),
+            (106, "2024-01-02"),
+            (109, "Copyright"),
+            (112, "Source edition"),
+            (524, "de"),
+        ] {
+            assert!(records
+                .iter()
+                .any(|(ty, value)| (*ty, value.as_str()) == expected));
+        }
+        assert!(!records.iter().any(|(ty, _)| matches!(ty, 113 | 501)));
     }
 }
 


### PR DESCRIPTION
## Summary
- preserve publisher, subjects, publication date, contributors, rights, source, and language from EPUB metadata
- repeat multi-value EXTH records and omit duplicate contributors/authors
- avoid synthesized ASIN, document type, and series metadata

## Verification
- `cargo test` (29 passed)
- 55/55 local samples converted internally
- 55/55 internal MOBIs round-tripped through Calibre
- 55/55 Calibre benchmark conversions succeeded
- metadata matched Calibre for authors, publisher, and language across all samples; one tags difference and publication-date differences reflect generator/source interpretation
- mandatory regression sample passed

No source books, generated outputs, extracted text, or private paths are included.
